### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "lodash": "latest",
     "semver": "1.1.x",
     "temp": "0.4.x",
-    "node-minify": "0.6.x",
+    "node-minify": "0.7.x",
     "wrench": "1.4.x",
-    "uglify-js": "1.3.4"
+    "uglify-js": "2.3.x"
   },
   "keywords": [
     "gruntplugin", "lodash", "underscore", "custom", "builder"


### PR DESCRIPTION
This is just a dependency update to omit the npm deprecated warnings triggered by node-minify.

```
npm WARN deprecated uglify-js2@2.1.11: You can now install this using uglify-js@2.2.0 node_modules/uglify-js
npm WARN deprecated ├── source-map@0.1.8 (amdefine@0.0.4)
npm WARN deprecated └── optimist@0.3.5 (wordwrap@0.0.2)
```
